### PR TITLE
Fix GitHub Actions build

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -7,8 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: 17
-          distribution: adopt
+          java-version: 21
+          distribution: temurin
       - name: Build
         run: ./gradlew build
       - name: Release

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,15 +7,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
       - name: Build
         run: ./gradlew build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: build/libs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: 17
-          distribution: adopt
+          java-version: 21
+          distribution: temurin
       - name: Build
         run: ./gradlew build
       - name: Upload artifacts


### PR DESCRIPTION
## Summary
- update actions/setup-java to use Java 21 in workflows

## Testing
- `./gradlew build` *(fails: plugin fabric-loom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842da51afe4832686e26307fd8e178e